### PR TITLE
#161704324 Reset Password should be validated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Authors Haven - A Social platform for the creative at heart.
 =======
-[![Coverage Status](https://coveralls.io/repos/github/andela/ah-maps/badge.svg?branch=ch-codeclimate-161255235)](https://coveralls.io/github/andela/ah-maps?branch=ch-codeclimate-161255235) [![Build Status](https://travis-ci.org/andela/ah-maps.svg?branch=develop)](https://travis-ci.org/andela/ah-maps)
+[![Coverage Status](https://coveralls.io/repos/github/andela/ah-maps/badge.svg?branch=develop)](https://coveralls.io/github/andela/ah-maps?branch=develop) [![Build Status](https://travis-ci.org/andela/ah-maps.svg?branch=develop)](https://travis-ci.org/andela/ah-maps)
 
 ## Vision
 Create a community of like minded authors to foster inspiration and innovation

--- a/authors/apps/authentication/backends.py
+++ b/authors/apps/authentication/backends.py
@@ -9,7 +9,9 @@ from .models import User
 
 class JWTAuthentication(authentication.BaseAuthentication):
 
+
     keyword = "Bearer"
+
 
     def authenticate(self, request):
         """
@@ -19,6 +21,7 @@ class JWTAuthentication(authentication.BaseAuthentication):
         request.user = None
 
         # returns Authorization header as a bytestring
+
 
         auth_header = authentication.get_authorization_header(request).split()
 
@@ -48,7 +51,6 @@ class JWTAuthentication(authentication.BaseAuthentication):
 
         try:
             user = User.objects.get(pk=payload['id'])
-            request.user = user
         except User.DoesNotExist:
             raise exceptions.AuthenticationFailed('No user found!')
         if not user.is_active:

--- a/authors/apps/authentication/test/test_user_api.py
+++ b/authors/apps/authentication/test/test_user_api.py
@@ -61,7 +61,7 @@ class UserTest(TestCase):
         self.assertEqual(200, response.status_code)
 
     def test_update_user_api(self):
-        response = self.client.put(self.update_user_url, self.body, format='json')
+        response = self.client.put(self.update_user_url, self.user_body, format='json')
         self.assertEqual(200, response.status_code)
 
     def test_update_user_without_password_field(self):
@@ -123,4 +123,3 @@ class UserTest(TestCase):
         activate = self.client.post(self.reset_url, data={"email":self.user_body.get('user').get('email')}, head={"Content-Type":"application/json"})
         self.assertEqual(activate.json().get('user').get('message'), 'An email has been sent to your account')
         self.assertEqual(activate.status_code, 200)
-

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -18,7 +18,7 @@ from .serializers import (
     LoginSerializer, RegistrationSerializer, UserSerializer,SocialSignUpSerializer
 )
 from django.contrib.auth.hashers import check_password
- 
+
 from .models import User
 
 auth = JWTAuthentication()
@@ -108,11 +108,12 @@ class ResetPasswordAPIView(APIView):
     serializer_class = UserSerializer
 
     def post(self, request):
-        serializer = self.serializer_class(request.user)
         email = request.data.get('email', None)
         if not email:
             message = {"message": "Please provide an email address"}
             return Response(message, status=status.HTTP_200_OK)
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(email)
         user = serializer.get_user(email=email)
         token = user.token
         serializer.reset_password(email, token, request)
@@ -131,6 +132,8 @@ class UpdateUserAPIView(APIView):
         if not password:
             message = {"message": "Please provide a password"}
             return Response(message, status=status.HTTP_200_OK)
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(password)
         if check_password(password, user[0].password):
             message = {"message": "Your new password can't be the same as your old password"}
             return Response(message, status=status.HTTP_200_OK)
@@ -144,7 +147,7 @@ class SocialSignUp(CreateAPIView):
     permission_classes = (AllowAny,)
     renderer_classes = (UserJSONRenderer,)
     serializer_class = SocialSignUpSerializer
-    
+
 
     def create(self, request, *args, **kwargs):
         """ Function to interrupt social_auth authentication pipeline"""
@@ -192,7 +195,7 @@ class SocialSignUp(CreateAPIView):
                     "details": str(error)
                 }
             }, status=status.HTTP_400_BAD_REQUEST)
-        
+
         except AuthTokenError as error:
              return Response({
                "error":"invalid credentials",
@@ -207,13 +210,13 @@ class SocialSignUp(CreateAPIView):
 
         except HTTPError as error:
             #catch any error as a result of the authentication
-            return Response({ 
+            return Response({
                 "error" : "invalid token",
                 "details":str(error)
                 },status=status.HTTP_400_BAD_REQUEST)
-        
+
         except AuthForbidden as error:
-            return Response({ 
+            return Response({
                 "error" : "invalid token",
                 "details":str(error)
                 },status=status.HTTP_400_BAD_REQUEST)
@@ -231,4 +234,3 @@ class SocialSignUp(CreateAPIView):
         else:
             return Response({"errors": "Could not authenticate"},
                             status=status.HTTP_400_BAD_REQUEST)
-              


### PR DESCRIPTION
#### What does this PR do?
- It ensures that the new password entered by the user when resetting password is valid
- It ensures that the email address entered for sending reset link is also validated
#### Description of Bug to be fixed?
Previously, the new password entered could be as small as one character since it wasn't passed through the data validators. This PR ensures that when resetting the password, the user must enter a password that is at least 8 characters long, has at least one number and has not more than 128 characters.
The email entered for sending the reset link must also be a valid email
#### How should this be manually tested?
- Clone the repo then cd into the ah-maps folder
- RUN python manage.py runserver
- Use POSTMAN
- Create a user through the /api/users/ endpoint
- Activate the user from your email account
- Request to change password using your email at /api/user/resetpassword
- Copy the link sent to your email account and paste it in postman
- add your new invalid password as a json object with 'password' as the key and send
#### What are the relevant pivotal tracker stories?
[#161704324](https://www.pivotaltracker.com/story/show/161704324)
#### Screenshots
<img width="1280" alt="screen shot 2018-11-04 at 20 52 58" src="https://user-images.githubusercontent.com/36792685/47967892-a510c280-e073-11e8-895b-a4dacd847ddf.png">
