### PR TITLE
(fix)(registration): User should not repeat a username in different case

### DIFF
--- a/authors/apps/authentication/test/test_user_api.py
+++ b/authors/apps/authentication/test/test_user_api.py
@@ -24,7 +24,6 @@ class UserTest(TestCase):
                 'email': faker.email(),
                 'password': faker.password()
             }
-
         self.user_body = {
                 'username': self.user.username,
                 'email': self.user.email,
@@ -101,6 +100,12 @@ class UserTest(TestCase):
         self.assertEqual(400, response4.status_code)
         self.assertEqual(400, response5.status_code)
         self.assertEqual(400, response6.status_code)
+    
+    def test_same_case(self):
+        self.user_body.update({'username':self.user_body['username'].upper()})
+        response= self.client.post(self.create_url, self.user_body, format='json')
+
+        self.assertEqual(400, response.status_code)
 
     def test_user_login(self):
         register= self.client.post(self.create_url, self.body, format='json')

--- a/authors/apps/authentication/test/test_user_api.py
+++ b/authors/apps/authentication/test/test_user_api.py
@@ -106,7 +106,7 @@ class UserTest(TestCase):
         response= self.client.post(self.create_url, self.user_body, format='json')
     
         self.assertEqual(400, response.status_code)
-        self.assertEqual('Sorry, this username is already in use.', code='unique', response.data['errors']['username'])
+        self.assertEqual('Sorry, this username is already in use.',response.data['errors']['username'][0])
 
     def test_user_login(self):
         register= self.client.post(self.create_url, self.body, format='json')

--- a/authors/apps/authentication/test/test_user_api.py
+++ b/authors/apps/authentication/test/test_user_api.py
@@ -104,8 +104,9 @@ class UserTest(TestCase):
     def test_same_case(self):
         self.user_body.update({'username':self.user_body['username'].upper()})
         response= self.client.post(self.create_url, self.user_body, format='json')
-
+    
         self.assertEqual(400, response.status_code)
+        self.assertEqual('Sorry, this username is already in use.', code='unique', response.data['errors']['username'])
 
     def test_user_login(self):
         register= self.client.post(self.create_url, self.body, format='json')

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -30,6 +30,7 @@ class RegistrationAPIView(CreateAPIView):
     serializer_class = RegistrationSerializer
 
     def post(self, request):
+        request.data['username']=request.data['username'].lower()
         user = request.data
         # The create serializer, validate serializer, save serializer pattern
         # below is common and you will see it a lot throughout this course and


### PR DESCRIPTION
#### What does this PR do?
-Fix the bug in registration where username can be repeated in different cases
#### Description of Task to be completed?
-Set the username to lowercase before passing to the serializer
#### How should this be manually tested?
-access the endpoint 
```api/users/```
-add a username in lowercase e.g mirriam
-use the same username in different case e.g Mirriam
#### What are the relevant pivotal tracker stories?
[Validation error messages](https://www.pivotaltracker.com/story/show/161255239)
#### Screenshots (if appropriate)
<img width="1095" alt="screenshot 2018-11-08 at 12 02 24" src="https://user-images.githubusercontent.com/31400129/48188209-3de25f00-e34e-11e8-9d5d-d51dc46b331a.png">
<img width="1117" alt="screenshot 2018-11-08 at 12 02 46" src="https://user-images.githubusercontent.com/31400129/48188211-433fa980-e34e-11e8-8c54-1cd414d0983f.png">