### PR TITLE
#161255258 Share articles across different channels

### DIFF
--- a/authors/apps/article/api/serializers.py
+++ b/authors/apps/article/api/serializers.py
@@ -40,6 +40,10 @@ class ArticleSerializer(serializers.ModelSerializer):
     my_highlights = serializers.SerializerMethodField(read_only=True)
     read_count = serializers.SerializerMethodField(read_only=True)
     tags = TagRelation(many=True, required=False)
+    facebook = serializers.SerializerMethodField(read_only=True)
+    twitter= serializers.SerializerMethodField(read_only=True)
+    Linkedin= serializers.SerializerMethodField(read_only=True)
+    mail= serializers.SerializerMethodField(read_only=True)
 
 
     class Meta:
@@ -50,13 +54,15 @@ class ArticleSerializer(serializers.ModelSerializer):
             'author', 'favorited',
             'favorites_count', 'liked_by',
             'disliked_by', 'image_file', 'rating',
-            'update_url', 'delete_url', 'reading_time', 'like_count', 'dislike_count', 'my_highlights', 'read_count', 'tags',)
+            'update_url', 'delete_url', 'reading_time', 'like_count',
+            'dislike_count', 'my_highlights', 'read_count', 'tags',
+            'facebook', 'twitter', 'Linkedin', 'mail')
 
     def get_favorited(self, obj):
         """Get favourited."""
         user = self.context['request'].user
         return True if obj.is_favorited(user) > 0 else False
-
+               
     def get_favorites_count(self, obj):
         """Get favourited count."""
         return obj.is_favorited()
@@ -121,6 +127,22 @@ class ArticleSerializer(serializers.ModelSerializer):
         instance.save()
 
         return instance
+
+    def get_facebook(self,obj):
+        request = self.context.get("request")
+        return 'http://www.facebook.com/sharer.php?u='+obj.article_url(request=request)
+
+    def get_twitter(self,obj):
+        request = self.context.get("request")
+        return 'https://twitter.com/share?url='+obj.article_url(request=request)+'&amp;text=Checkout this great read: '
+
+    def get_Linkedin(self,obj):
+        request = self.context.get("request")
+        return 'http://www.linkedin.com/shareArticle?url='+obj.article_url(request=request)+ '&title=Checkout this great read: '
+
+    def get_mail(self,obj):
+        request = self.context.get("request")
+        return  'mailto:?subject=Checkout this great read&body={}'.format(obj.article_url(request=request))
 
 
 class ArticleCreateSerializer(serializers.ModelSerializer):

--- a/authors/apps/article/models.py
+++ b/authors/apps/article/models.py
@@ -8,6 +8,7 @@ from autoslug import AutoSlugField
 from ..tags.models import Tag
 from authors.apps.profile.models import Profile
 
+from rest_framework.reverse import reverse as api_reverse
 
 
 
@@ -104,6 +105,9 @@ class Article(models.Model):
     def __str__(self):
         """Print out as title."""
         return self.title
+
+    def article_url(self,request=None):
+        return api_reverse("article_api:detail",kwargs={'slug':self.slug},request=request)
 
     def is_favorited(self, user=None):
         """Get favourited articles."""

--- a/authors/apps/article/tests/test_article_api.py
+++ b/authors/apps/article/tests/test_article_api.py
@@ -108,7 +108,20 @@ class ArticleApiTest(TestCase):
     def test_get_dislikers(self):
         res = self.client.get(self.dislikers_url)
         self.assertEqual(200, res.status_code)
+
     def test_reading_time_of_article(self):
         response = self.client.get(self.retrieve_url)
         self.assertEqual(response.json().get('reading_time'), '1 min read')
+    
+    def test_social_media_sharing_links(self):
+        response = self.client.get(self.retrieve_url)
+        self.assertIn('http://www.facebook.com/sharer.php?u=', response.json().get('facebook'))
+        self.assertIn('https://twitter.com/share?url=', response.json().get('twitter'))
+        self.assertIn('http://www.linkedin.com/shareArticle?url=', response.json().get('Linkedin'))
+        self.assertIn('http://www.linkedin.com/shareArticle?url=', response.json().get('Linkedin'))
+        self.assertIn('mailto:?subject=Checkout this great read', response.json().get('mail'))
+
+
+
+
         


### PR DESCRIPTION
#### What does this PR do?

This PR adds functionality to share articles across different social platforms.

#### Description of Task to be completed?

Have the following endpoints return facebook, twitter, Linkedin and mail sharing links.
`GET /article`
`GET /article/detail/<slug>/`

#### How should this be manually tested?
After cloning the repo, cd into it and hit the endpoints stated above to get the social media sharing links.

#### Any background context you want to provide?

The sharing links should allow for the article link to be in the sharing body
#### What are the relevant pivotal tracker stories?

[#161255258](https://www.pivotaltracker.com/story/show/161255258)
#### Screenshots (if appropriate)

<img width="1280" alt="screen shot 2018-11-21 at 09 07 39" src="https://user-images.githubusercontent.com/37045046/48822134-f061eb00-ed6c-11e8-82a6-dcbf261463be.png">
